### PR TITLE
Upgrade db-migration to use Spring 5 and other libraries version

### DIFF
--- a/db-migration-maven-plugin/pom.xml
+++ b/db-migration-maven-plugin/pom.xml
@@ -12,21 +12,21 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>3.3.0</version>
+            <version>1.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -43,8 +43,8 @@
             <version>2.1.0</version>
             <exclusions>
                 <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/db-migration-maven-plugin/pom.xml
+++ b/db-migration-maven-plugin/pom.xml
@@ -13,14 +13,15 @@
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>1.1</version>
+            <version>3.3.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -57,7 +58,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>${spring.version}</version>
+            <version>5.3.27</version>
         </dependency>
 
         <dependency>
@@ -69,11 +70,13 @@
         <dependency>
             <groupId>com.google.collections</groupId>
             <artifactId>google-collections</artifactId>
+            <version>1.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <version>2.0.7</version>
         </dependency>
     </dependencies>
 </project>

--- a/db-migration-maven-plugin/src/test/test-project/pom.xml
+++ b/db-migration-maven-plugin/src/test/test-project/pom.xml
@@ -29,9 +29,9 @@
                         <version>1.1.111</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>5.1.6</version>
+                        <groupId>org.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>8.0.33</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/db-migration/pom.xml
+++ b/db-migration/pom.xml
@@ -16,32 +16,37 @@
           - Test
           -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <version>2.1.214</version>
             <scope>test</scope>
         </dependency>
 
@@ -52,8 +57,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -84,37 +89,42 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <!-- Spring and Related -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
+            <version>${spring.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
+            <version>${spring.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -123,6 +133,12 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/db-migration/src/main/java/com/carbonfive/db/migration/AbstractMigration.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/AbstractMigration.java
@@ -1,6 +1,6 @@
 package com.carbonfive.db.migration;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/db-migration/src/main/java/com/carbonfive/db/migration/DataSourceMigrationManager.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/DataSourceMigrationManager.java
@@ -2,10 +2,10 @@ package com.carbonfive.db.migration;
 
 import com.carbonfive.db.jdbc.DatabaseType;
 import com.carbonfive.db.jdbc.DatabaseUtils;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.lang.time.DurationFormatUtils;
-import org.apache.commons.lang.time.StopWatch;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;

--- a/db-migration/src/main/java/com/carbonfive/db/migration/DriverManagerMigrationManager.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/DriverManagerMigrationManager.java
@@ -7,11 +7,11 @@ public class DriverManagerMigrationManager extends DataSourceMigrationManager
 {
     public DriverManagerMigrationManager(String driver, String url, String username, String password)
     {
-        super(new DriverManagerDataSource(driver, url, username, password));
+        super(new DriverManagerDataSource(url, username, password));
     }
 
     public DriverManagerMigrationManager(String driver, String url, String username, String password, DatabaseType dbType)
     {
-        super(new DriverManagerDataSource(driver, url, username, password), dbType);
+        super(new DriverManagerDataSource(url, username, password), dbType);
     }
 }

--- a/db-migration/src/main/java/com/carbonfive/db/migration/GroovyMigration.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/GroovyMigration.java
@@ -4,7 +4,7 @@ import com.carbonfive.db.jdbc.DatabaseType;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.springframework.core.io.Resource;
 
 import java.io.IOException;
@@ -12,39 +12,27 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-public class GroovyMigration extends AbstractMigration
-{
+public class GroovyMigration extends AbstractMigration {
     private final Resource script;
 
-    public GroovyMigration(String version, Resource script)
-    {
+    public GroovyMigration(String version, Resource script) {
         super(version, script.getFilename());
         this.script = script;
     }
 
-    public void migrate(DatabaseType dbType, Connection connection)
-    {
+    public void migrate(DatabaseType dbType, Connection connection) {
         Binding binding = new Binding();
         binding.setVariable("connection", connection);
         GroovyShell shell = new GroovyShell(binding);
 
         InputStream inputStream = null;
-        try
-        {
+        try {
             inputStream = script.getInputStream();
             shell.evaluate(IOUtils.toString(inputStream));
             Validate.isTrue(!connection.isClosed(), "JDBC Connection should not be closed.");
-        }
-        catch (IOException e)
-        {
+        } catch (IOException | SQLException e) {
             throw new MigrationException(e);
-        }
-        catch (SQLException e)
-        {
-            throw new MigrationException(e);
-        }
-        finally
-        {
+        } finally {
             IOUtils.closeQuietly(inputStream);
         }
     }

--- a/db-migration/src/main/java/com/carbonfive/db/migration/Migration.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/Migration.java
@@ -1,8 +1,8 @@
 package com.carbonfive.db.migration;
 
 import com.carbonfive.db.jdbc.DatabaseType;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
 

--- a/db-migration/src/main/java/com/carbonfive/db/migration/ResourceMigrationResolver.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/ResourceMigrationResolver.java
@@ -1,8 +1,8 @@
 package com.carbonfive.db.migration;
 
 import com.carbonfive.db.jdbc.DatabaseType;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,8 +12,8 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import java.io.IOException;
 import java.util.*;
 
-import static org.apache.commons.collections.CollectionUtils.find;
-import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.collections4.CollectionUtils.find;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.util.StringUtils.collectionToCommaDelimitedString;
 
 /**

--- a/db-migration/src/main/java/com/carbonfive/db/migration/SQLScriptMigration.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/SQLScriptMigration.java
@@ -3,7 +3,7 @@ package com.carbonfive.db.migration;
 import com.carbonfive.db.jdbc.DatabaseType;
 import com.carbonfive.db.jdbc.ScriptRunner;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.springframework.core.io.Resource;
 
 import java.io.IOException;

--- a/db-migration/src/main/java/com/carbonfive/db/migration/SimpleVersionStrategy.java
+++ b/db-migration/src/main/java/com/carbonfive/db/migration/SimpleVersionStrategy.java
@@ -1,7 +1,7 @@
 package com.carbonfive.db.migration;
 
 import com.carbonfive.db.jdbc.DatabaseType;
-import org.apache.commons.collections.map.DefaultedMap;
+import org.apache.commons.collections4.map.DefaultedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/db-migration/src/test/java/com/carbonfive/db/migration/DataSourceMigrationManagerTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/DataSourceMigrationManagerTest.java
@@ -2,7 +2,7 @@ package com.carbonfive.db.migration;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
 
@@ -18,7 +18,7 @@ public class DataSourceMigrationManagerTest
     static final String BAD_SCRIPT = "classpath:/test_migrations/bad_script_1/";
 
     private DataSourceMigrationManager migrationManager;
-    private SimpleJdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     @Before
     public void setup()
@@ -26,14 +26,14 @@ public class DataSourceMigrationManagerTest
         DataSource dataSource = DatabaseTestUtils.createUniqueDataSource();
         migrationManager = new DataSourceMigrationManager(dataSource);
 
-        jdbcTemplate = new SimpleJdbcTemplate(dataSource);
+        jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     @Test
     public void enableMigrationsShouldCreateSchemaTrackingTable()
     {
         migrationManager.enableMigrations();
-        jdbcTemplate.queryForInt("select count(*) from schema_version"); // Throws exception if table doesn't exist.
+        jdbcTemplate.queryForObject("select count(*) from schema_version", Integer.class); // Throws exception if table doesn't exist.
     }
 
     @Test
@@ -44,7 +44,7 @@ public class DataSourceMigrationManagerTest
         migrationManager.migrate();
         assertThat(migrationManager.validate(), is(true));
 
-        assertThat(jdbcTemplate.queryForInt("select count(*) from users"), is(3));
+        assertThat(jdbcTemplate.queryForObject("select count(*) from users", Integer.class), is(3));
     }
 
     @Test
@@ -62,8 +62,8 @@ public class DataSourceMigrationManagerTest
         migrationManager.migrate();
         assertThat(migrationManager.validate(), is(true));
 
-        assertThat(jdbcTemplate.queryForInt("select count(*) from users"), is(3));
-        assertThat(jdbcTemplate.queryForInt("select count(*) from trips"), is(3));
+        assertThat(jdbcTemplate.queryForObject("select count(*) from users", Integer.class), is(3));
+        assertThat(jdbcTemplate.queryForObject("select count(*) from trips", Integer.class), is(3));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class DataSourceMigrationManagerTest
         {
         }
 
-        assertThat(jdbcTemplate.queryForInt("select count(*) from trips"), is(2));
+        assertThat(jdbcTemplate.queryForObject("select count(*) from trips", Integer.class), is(2));
         assertThat(migrationManager.validate(), is(false));
     }
 }

--- a/db-migration/src/test/java/com/carbonfive/db/migration/GroovyMigrationTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/GroovyMigrationTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -30,7 +30,7 @@ public class GroovyMigrationTest
         new GroovyMigration("1", script).migrate(DatabaseType.H2, connection);
         connection.close();
 
-        SimpleJdbcTemplate jdbcTemplate = new SimpleJdbcTemplate(dataSource);
-        assertThat(jdbcTemplate.queryForInt("select count(*) from users"), is(1));
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        assertThat(jdbcTemplate.queryForObject("select count(*) from users", Integer.class), is(1));
     }
 }

--- a/db-migration/src/test/java/com/carbonfive/db/migration/H2MigrationTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/H2MigrationTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import javax.sql.DataSource;
@@ -13,7 +13,7 @@ import javax.sql.DataSource;
 public class H2MigrationTest
 {
     private DataSourceMigrationManager migrationManager;
-    private SimpleJdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     private static final String URL = "jdbc:h2:mem:h2-migration-test;DB_CLOSE_DELAY=-1";
     private static final String USERNAME = "sa";
@@ -26,7 +26,7 @@ public class H2MigrationTest
         migrationManager = new DataSourceMigrationManager(dataSource);
         migrationManager.setMigrationResolver(new ResourceMigrationResolver("classpath:/test_migrations/h2/"));
 
-        jdbcTemplate = new SimpleJdbcTemplate(dataSource);
+        jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     @Test
@@ -34,6 +34,6 @@ public class H2MigrationTest
     {
         migrationManager.migrate();
 
-        assertThat(jdbcTemplate.queryForInt("select count(version) from schema_version"), is(2));
+        assertThat(jdbcTemplate.queryForObject("select count(version) from schema_version", Integer.class), is(2));
     }
 }

--- a/db-migration/src/test/java/com/carbonfive/db/migration/HSQLMigrationTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/HSQLMigrationTest.java
@@ -1,19 +1,20 @@
 package com.carbonfive.db.migration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import org.hsqldb.jdbcDriver;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import javax.sql.DataSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 public class HSQLMigrationTest
 {
     private DataSourceMigrationManager migrationManager;
-    private SimpleJdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     private static final String URL = "jdbc:hsqldb:file:./tmp/hsql-migration-test";
     private static final String USERNAME = "sa";
@@ -26,7 +27,7 @@ public class HSQLMigrationTest
         migrationManager = new DataSourceMigrationManager(dataSource);
         migrationManager.setMigrationResolver(new ResourceMigrationResolver("classpath:/test_migrations/hsql/"));
 
-        jdbcTemplate = new SimpleJdbcTemplate(dataSource);
+        jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     @Test
@@ -34,6 +35,6 @@ public class HSQLMigrationTest
     {
         migrationManager.migrate();
 
-        assertThat(jdbcTemplate.queryForInt("select count(version) from schema_version"), is(2));
+        assertThat(jdbcTemplate.queryForObject("select count(version) from schema_version", Integer.class), is(2));
     }
 }

--- a/db-migration/src/test/java/com/carbonfive/db/migration/MySQLMigrationTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/MySQLMigrationTest.java
@@ -2,9 +2,11 @@ package com.carbonfive.db.migration;
 
 import com.carbonfive.db.jdbc.schema.CreateDatabase;
 import com.carbonfive.db.jdbc.schema.DropDatabase;
-import com.mysql.jdbc.Driver;
+import com.mysql.cj.jdbc.Driver;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,11 +14,11 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import javax.sql.DataSource;
+
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
 
-public class MySQLMigrationTest
-{
+public class MySQLMigrationTest {
     private DataSourceMigrationManager migrationManager;
     private JdbcTemplate jdbcTemplate;
 
@@ -25,8 +27,7 @@ public class MySQLMigrationTest
     private static final String PASSWORD = "dev";
 
     @Before
-    public void setup() throws Exception
-    {
+    public void setup() throws Exception {
         new CreateDatabase(URL, USERNAME, PASSWORD).execute();
 
         DataSource dataSource = new SimpleDriverDataSource(new Driver(), URL, USERNAME, PASSWORD);
@@ -37,32 +38,27 @@ public class MySQLMigrationTest
     }
 
     @After
-    public void teardown() throws Exception
-    {
+    public void teardown() throws Exception {
         new DropDatabase(URL, USERNAME, PASSWORD).execute();
     }
 
     @Test
-    public void singleLineFunction()
-    {
+    public void singleLineFunction() {
         jdbcTemplate.update("CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello, ',s,'!');");
     }
 
     @Test
-    public void multiLineFunction()
-    {
+    public void multiLineFunction() {
         jdbcTemplate.update("CREATE FUNCTION weighted_average (n1 INT, n2 INT, n3 INT, n4 INT) RETURNS INT DETERMINISTIC BEGIN DECLARE avg INT; SET avg = (n1+n2+n3*2+n4*4)/8; RETURN avg; END;");
     }
 
     @Test
-    public void storedProcedure()
-    {
+    public void storedProcedure() {
         jdbcTemplate.update("CREATE PROCEDURE payment(payment_amount DECIMAL(6,2), payment_seller_id INT) BEGIN DECLARE n DECIMAL(6,2); SET n = payment_amount - 1.00; INSERT INTO Moneys VALUES (n, CURRENT_DATE); IF payment_amount > 1.00 THEN UPDATE Sellers SET commission = commission + 1.00 WHERE seller_id = payment_seller_id; END IF; END;");
     }
 
     @Test
-    public void migrateShouldApplyPendingMigrations()
-    {
+    public void migrateShouldApplyPendingMigrations() {
         migrationManager.migrate();
 
         assertThat(jdbcTemplate.queryForObject("select count(version) from schema_version", Integer.class), is(5));

--- a/db-migration/src/test/java/com/carbonfive/db/migration/MySQLMigrationTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/MySQLMigrationTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.core.Is.is;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import javax.sql.DataSource;
@@ -18,7 +18,7 @@ import static java.lang.System.getProperty;
 public class MySQLMigrationTest
 {
     private DataSourceMigrationManager migrationManager;
-    private SimpleJdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     private static final String URL = format("jdbc:mysql://%s/mysql_migration_test", getProperty("jdbc.host", "localhost"));
     private static final String USERNAME = "dev";
@@ -33,7 +33,7 @@ public class MySQLMigrationTest
         migrationManager = new DataSourceMigrationManager(dataSource);
         migrationManager.setMigrationResolver(new ResourceMigrationResolver("classpath:/test_migrations/mysql_50/"));
 
-        jdbcTemplate = new SimpleJdbcTemplate(dataSource);
+        jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     @After
@@ -65,9 +65,9 @@ public class MySQLMigrationTest
     {
         migrationManager.migrate();
 
-        assertThat(jdbcTemplate.queryForInt("select count(version) from schema_version"), is(5));
+        assertThat(jdbcTemplate.queryForObject("select count(version) from schema_version", Integer.class), is(5));
 
-        assertThat(jdbcTemplate.queryForInt("select count(*) from books"), is(9));
-        assertThat(jdbcTemplate.queryForInt("select count(*) from authors"), is(2));
+        assertThat(jdbcTemplate.queryForObject("select count(*) from books", Integer.class), is(9));
+        assertThat(jdbcTemplate.queryForObject("select count(*) from authors", Integer.class), is(2));
     }
 }

--- a/db-migration/src/test/java/com/carbonfive/db/migration/PostgreSQLMigrationTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/PostgreSQLMigrationTest.java
@@ -6,7 +6,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.postgresql.Driver;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import javax.sql.DataSource;
@@ -19,7 +19,7 @@ import static org.hamcrest.core.Is.is;
 public class PostgreSQLMigrationTest
 {
     private DataSourceMigrationManager migrationManager;
-    private SimpleJdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     private static final String URL = format("jdbc:postgresql://%s/postgresql_migration_test", getProperty("jdbc.host", "localhost"));
     private static final String USERNAME = "dev";
@@ -34,7 +34,7 @@ public class PostgreSQLMigrationTest
         migrationManager = new DataSourceMigrationManager(dataSource);
         migrationManager.setMigrationResolver(new ResourceMigrationResolver("classpath:/test_migrations/postgresql_8/"));
 
-        jdbcTemplate = new SimpleJdbcTemplate(dataSource);
+        jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     @After
@@ -48,6 +48,6 @@ public class PostgreSQLMigrationTest
     {
         migrationManager.migrate();
 
-        assertThat(jdbcTemplate.queryForInt("select count(version) from schema_version"), is(2));
+        assertThat(jdbcTemplate.queryForObject("select count(version) from schema_version", Integer.class), is(2));
     }
 }

--- a/db-migration/src/test/java/com/carbonfive/db/migration/SQLServerMigrationTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/SQLServerMigrationTest.java
@@ -10,7 +10,7 @@ import org.junit.After;
 import static org.junit.Assume.assumeThat;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import javax.sql.DataSource;
@@ -20,7 +20,7 @@ import java.net.UnknownHostException;
 public class SQLServerMigrationTest
 {
     private DataSourceMigrationManager migrationManager;
-    private SimpleJdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     private static final String URL = "jdbc:jtds:sqlserver://sqlserver2000/sqlserver_migration_test";
     private static final String USERNAME = "dev";
@@ -40,7 +40,7 @@ public class SQLServerMigrationTest
         migrationManager = new DataSourceMigrationManager(dataSource);
         migrationManager.setMigrationResolver(new ResourceMigrationResolver("classpath:/test_migrations/sqlserver_2000/"));
 
-        jdbcTemplate = new SimpleJdbcTemplate(dataSource);
+        jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     @After
@@ -54,6 +54,6 @@ public class SQLServerMigrationTest
     {
         migrationManager.migrate();
 
-        assertThat(jdbcTemplate.queryForInt("select count(version) from schema_version"), is(2));
+        assertThat(jdbcTemplate.queryForObject("select count(version) from schema_version", Integer.class), is(2));
     }
 }

--- a/db-migration/src/test/java/com/carbonfive/db/migration/SimpleVersionStrategyTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/SimpleVersionStrategyTest.java
@@ -3,7 +3,7 @@ package com.carbonfive.db.migration;
 import com.carbonfive.db.jdbc.DatabaseType;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -42,8 +42,8 @@ public class SimpleVersionStrategyTest
         strategy.enableVersioning(DatabaseType.H2, connection);
         connection.close();
 
-        SimpleJdbcTemplate jdbcTemplate = new SimpleJdbcTemplate(dataSource);
-        jdbcTemplate.queryForInt("select count(*)" + VERSION_COLUMN + " from " + TABLE_NAME); // Throws exception is table doesn't exist.
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.queryForObject("select count(*)" + VERSION_COLUMN + " from " + TABLE_NAME, Integer.class); // Throws exception is table doesn't exist.
     }
 
     @Test
@@ -79,15 +79,15 @@ public class SimpleVersionStrategyTest
         strategy.recordMigration(DatabaseType.H2, connection, v1, new Date(), 768);
         connection.close();
 
-        SimpleJdbcTemplate jdbcTemplate = new SimpleJdbcTemplate(dataSource);
-        assertThat(jdbcTemplate.queryForInt("select count(*) from " + TABLE_NAME), is(1));
-        assertThat(jdbcTemplate.queryForObject("select " + VERSION_COLUMN + " from " + TABLE_NAME, String.class), is(v1));
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        assertThat(jdbcTemplate.queryForObject("select count(*) from " + TABLE_NAME, Integer.class), is(1));
+        assertThat(jdbcTemplate.queryForObject("select " + VERSION_COLUMN + " from " + TABLE_NAME, Integer.class, String.class), is(v1));
 
         connection = dataSource.getConnection();
         strategy.recordMigration(DatabaseType.H2, connection, v2, new Date(), 231);
         connection.close();
 
-        assertThat(jdbcTemplate.queryForInt("select count(*) from " + TABLE_NAME), is(2));
+        assertThat(jdbcTemplate.queryForObject("select count(*) from " + TABLE_NAME, Integer.class), is(2));
 
         connection = dataSource.getConnection();
         Set<String> appliedMigrations = strategy.appliedMigrations(DatabaseType.H2, connection);

--- a/db-migration/src/test/java/com/carbonfive/db/migration/SimpleVersionStrategyTest.java
+++ b/db-migration/src/test/java/com/carbonfive/db/migration/SimpleVersionStrategyTest.java
@@ -81,7 +81,7 @@ public class SimpleVersionStrategyTest
 
         JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
         assertThat(jdbcTemplate.queryForObject("select count(*) from " + TABLE_NAME, Integer.class), is(1));
-        assertThat(jdbcTemplate.queryForObject("select " + VERSION_COLUMN + " from " + TABLE_NAME, Integer.class, String.class), is(v1));
+        assertThat(jdbcTemplate.queryForObject("select " + VERSION_COLUMN + " from " + TABLE_NAME, String.class), is(v1));
 
         connection = dataSource.getConnection();
         strategy.recordMigration(DatabaseType.H2, connection, v2, new Date(), 231);

--- a/db-support/pom.xml
+++ b/db-support/pom.xml
@@ -15,9 +15,9 @@
           - Test
           -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -137,6 +137,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.7</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/db-support/pom.xml
+++ b/db-support/pom.xml
@@ -16,67 +16,84 @@
           -->
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
+            <version>5.1.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.mockrunner</groupId>
-            <artifactId>mockrunner</artifactId>
+            <artifactId>mockrunner-jms</artifactId>
+            <version>2.0.6</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mockrunner</groupId>
+            <artifactId>mockrunner-jdbc</artifactId>
+            <version>2.0.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>oro</groupId>
             <artifactId>oro</artifactId>
+            <version>2.0.8</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>c3p0</groupId>
+            <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
+            <version>0.9.5.5</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <version>2.1.210</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>42.6.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>
             <artifactId>jtds</artifactId>
+            <version>1.3.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -84,32 +101,42 @@
         - Compile and Runtime
         -->
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
+            <version>${spring.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.7</version>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/db-support/src/main/java/com/carbonfive/db/hibernate/HibernateUtils.java
+++ b/db-support/src/main/java/com/carbonfive/db/hibernate/HibernateUtils.java
@@ -1,21 +1,14 @@
 package com.carbonfive.db.hibernate;
 
-import org.hibernate.*;
 
-import java.util.*;
+import org.hibernate.HibernateException;
+import org.hibernate.SessionFactory;
 
-public class HibernateUtils
-{
-    public static void clearSecondLevelCache(SessionFactory sessionFactory) throws HibernateException
-    {
-        for (String clazz : (Set<String>) sessionFactory.getAllClassMetadata().keySet())
-        {
-            sessionFactory.evictEntity(clazz);
-        }
-        for (String rolename : (Set<String>) sessionFactory.getAllCollectionMetadata().keySet())
-        {
-            sessionFactory.evictCollection(rolename);
-        }
-        sessionFactory.evictQueries();
+public class HibernateUtils {
+    public static void clearSecondLevelCache(SessionFactory sessionFactory) throws HibernateException {
+        sessionFactory.getCache().evictEntityData();
+        sessionFactory.getCache().evictAll();
+        sessionFactory.getCache().evictAllRegions();
+        sessionFactory.getCache().evictQueryRegions();
     }
 }

--- a/db-support/src/main/java/com/carbonfive/db/hibernate/repository/AbstractHibernateRepository.java
+++ b/db-support/src/main/java/com/carbonfive/db/hibernate/repository/AbstractHibernateRepository.java
@@ -1,103 +1,90 @@
 package com.carbonfive.db.hibernate.repository;
 
-import org.hibernate.*;
 
-import java.io.*;
-import java.lang.reflect.*;
-import java.util.*;
+import jakarta.persistence.criteria.CriteriaQuery;
+import org.hibernate.LockMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.usertype.ParameterizedType;
+import org.hibernate.usertype.UserCollectionType;
 
-public abstract class AbstractHibernateRepository<T, Id extends Serializable>
-{
+import java.io.Serializable;
+import java.util.List;
+
+public abstract class AbstractHibernateRepository<T, Id extends Serializable> {
     private Class<T> persistentClass;
 
     private SessionFactory sessionFactory;
 
-    @SuppressWarnings("unchecked")
-    public AbstractHibernateRepository()
-    {
-        this.persistentClass = (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+    public AbstractHibernateRepository() {
+        this.persistentClass = (Class<T>) ((UserCollectionType) getClass().getGenericSuperclass()).getCollectionClass();
     }
 
-    protected AbstractHibernateRepository(SessionFactory sessionFactory)
-    {
+    protected AbstractHibernateRepository(SessionFactory sessionFactory) {
         this();
         this.sessionFactory = sessionFactory;
     }
 
-    public Class<T> getPersistentClass()
-    {
+    public Class<T> getPersistentClass() {
         return persistentClass;
     }
 
-    public void flushSession()
-    {
+    public void flushSession() {
         getSession().flush();
     }
 
-    public void clearSession()
-    {
+    public void clearSession() {
         getSession().clear();
     }
 
-    @SuppressWarnings("unchecked")
-    public T findById(Id id, boolean lock)
-    {
+    public T findById(Id id, boolean lock) {
         T entity;
 
-        if (lock)
-        {
-            entity = (T) getSession().get(getPersistentClass(), id, LockMode.UPGRADE);
-        }
-        else
-        {
+        if (lock) {
+            entity = (T) getSession().get(getPersistentClass(), id, LockMode.UPGRADE_SKIPLOCKED);
+        } else {
             entity = (T) getSession().get(getPersistentClass(), id);
         }
 
         return entity;
     }
 
-    @SuppressWarnings("unchecked")
-    public List<T> findAll()
-    {
-        Criteria criteria = getSession().createCriteria(persistentClass);
-        return criteria.list();
+    public List<T> findAll() {
+        CriteriaQuery criteria = getSession()
+                .getEntityManagerFactory()
+                .createEntityManager()
+                .getCriteriaBuilder()
+                .createQuery(persistentClass);
+        return criteria.getOrderList();
     }
 
-    public T makePersistent(T entity)
-    {
+    public T makePersistent(T entity) {
         getSession().saveOrUpdate(entity);
         return entity;
     }
 
-    public void makeTransient(T entity)
-    {
+    public void makeTransient(T entity) {
         getSession().delete(entity);
     }
 
-    public void makeTransient(Id id)
-    {
+    public void makeTransient(Id id) {
         Object entity = getSession().get(getPersistentClass(), id);
         getSession().delete(entity);
     }
 
-    public void refresh(T entity)
-    {
+    public void refresh(T entity) {
         getSession().refresh(entity);
     }
 
-    @SuppressWarnings("unchecked")
-    public T merge(T entity)
-    {
+    public T merge(T entity) {
         return (T) getSession().merge(entity);
     }
 
-    protected Session getSession()
-    {
+    protected Session getSession() {
         return sessionFactory.getCurrentSession();
     }
 
-    public void setSessionFactory(SessionFactory sessionFactory)
-    {
+    public void setSessionFactory(SessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;
     }
 }

--- a/db-support/src/main/java/com/carbonfive/db/hibernate/sessionfactory/RoutingSessionFactory.java
+++ b/db-support/src/main/java/com/carbonfive/db/hibernate/sessionfactory/RoutingSessionFactory.java
@@ -1,159 +1,144 @@
 package com.carbonfive.db.hibernate.sessionfactory;
 
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.Metamodel;
 import org.hibernate.*;
-import org.hibernate.classic.Session;
-import org.hibernate.engine.*;
-import org.hibernate.metadata.*;
-import org.hibernate.stat.*;
+import org.hibernate.engine.spi.FilterDefinition;
+import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.stat.Statistics;
 
-import javax.naming.*;
-import java.io.*;
-import java.sql.*;
-import java.util.*;
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
-public abstract class RoutingSessionFactory implements SessionFactory
-{
-    //private boolean createNewSessionFactories = true;
-    private Map<Object, SessionFactory> sessionFactories = new HashMap<Object, SessionFactory>();
-    //private DataSourceFactory dataSourceFactory;
+public abstract class RoutingSessionFactory implements SessionFactory {
+    private Map<Object, SessionFactory> sessionFactories = new HashMap<>();
+    private EntityManager entityManager = getSessionFactory().createEntityManager();
 
-    public FilterDefinition getFilterDefinition(String filterName) throws HibernateException
-    {
+    public FilterDefinition getFilterDefinition(String filterName) throws HibernateException {
         return getSessionFactory().getFilterDefinition(filterName);
     }
 
-    public Session openSession(Connection connection)
-    {
-        return getSessionFactory().openSession(connection);
+    public Session openSession(Connection connection) {
+        return getSessionFactory()
+                .withOptions()
+                .connection(connection)
+                .openSession();
     }
 
-    public Session openSession(Interceptor interceptor) throws HibernateException
-    {
-        return getSessionFactory().openSession(interceptor);
+    public Session openSession(Interceptor interceptor) throws HibernateException {
+        return getSessionFactory()
+                .withOptions()
+                .interceptor(interceptor)
+                .openSession();
     }
 
-    public Session openSession(Connection connection, Interceptor interceptor)
-    {
-        return getSessionFactory().openSession(connection, interceptor);
+    public Session openSession(Connection connection, Interceptor interceptor) {
+        return getSessionFactory().withOptions()
+                .connection(connection)
+                .interceptor(interceptor)
+                .openSession();
     }
 
-    public Session openSession() throws HibernateException
-    {
+    public Session openSession() throws HibernateException {
         return getSessionFactory().openSession();
     }
 
-    public Session getCurrentSession() throws HibernateException
-    {
+    public Session getCurrentSession() throws HibernateException {
         return getSessionFactory().getCurrentSession();
     }
 
-    public ClassMetadata getClassMetadata(Class persistentClass) throws HibernateException
-    {
-        return getSessionFactory().getClassMetadata(persistentClass);
+    public MappingMetamodel getClassMetadata(Class persistentClass) throws HibernateException {
+        return entityManager.find(MappingMetamodel.class, persistentClass);
     }
 
-    public ClassMetadata getClassMetadata(String entityName) throws HibernateException
-    {
-        return getSessionFactory().getClassMetadata(entityName);
+    public MappingMetamodel getClassMetadata(String entityName) throws HibernateException {
+        ;
+        return entityManager.find(MappingMetamodel.class, new String(entityName));
     }
 
-    public CollectionMetadata getCollectionMetadata(String roleName) throws HibernateException
-    {
-        return getSessionFactory().getCollectionMetadata(roleName);
+    public Metamodel getCollectionMetadata(String roleName) throws HibernateException {
+        return entityManager.find(Metamodel.class, roleName);
     }
 
-    public Map getAllClassMetadata() throws HibernateException
-    {
-        return getSessionFactory().getAllClassMetadata();
+    public Metamodel getAllClassMetadata() throws HibernateException {
+        return entityManager.getMetamodel();
     }
 
-    public Map getAllCollectionMetadata() throws HibernateException
-    {
-        return getSessionFactory().getAllCollectionMetadata();
+    public Metamodel getAllCollectionMetadata() throws HibernateException {
+        return entityManager.getMetamodel();
     }
 
-    public Statistics getStatistics()
-    {
+    public Statistics getStatistics() {
         return getSessionFactory().getStatistics();
     }
 
-    public void close() throws HibernateException
-    {
+    public void close() throws HibernateException {
         getSessionFactory().close();
     }
 
-    public boolean isClosed()
-    {
+    public boolean isClosed() {
         return getSessionFactory().isClosed();
     }
 
-    public void evict(Class persistentClass) throws HibernateException
-    {
-        getSessionFactory().evict(persistentClass);
+    public void evict(Class persistentClass) throws HibernateException {
+        getSessionFactory().getCache().evict(persistentClass);
     }
 
-    public void evict(Class persistentClass, Serializable id) throws HibernateException
-    {
-        getSessionFactory().evict(persistentClass, id);
+    public void evict(Class persistentClass, Serializable id) throws HibernateException {
+        getSessionFactory().getCache().evict(persistentClass, id);
     }
 
-    public void evictEntity(String entityName) throws HibernateException
-    {
-        getSessionFactory().evictEntity(entityName);
+    public void evictEntity(String entityName) throws HibernateException {
+        getSessionFactory().getCache().evictEntityData(entityName);
     }
 
-    public void evictEntity(String entityName, Serializable id) throws HibernateException
-    {
-        getSessionFactory().evictEntity(entityName, id);
+    public void evictEntity(String entityName, Serializable id) throws HibernateException {
+        getSessionFactory().getCache().evictEntityData(entityName, id);
     }
 
-    public void evictCollection(String roleName) throws HibernateException
-    {
-        getSessionFactory().evictCollection(roleName);
+    public void evictCollection(String roleName) throws HibernateException {
+        getSessionFactory().getCache().evictCollectionData(roleName);
     }
 
-    public void evictCollection(String roleName, Serializable id) throws HibernateException
-    {
-        getSessionFactory().evictCollection(roleName, id);
+    public void evictCollection(String roleName, Serializable id) throws HibernateException {
+        getSessionFactory().getCache().evictCollectionData(roleName, id);
     }
 
-    public void evictQueries() throws HibernateException
-    {
-        getSessionFactory().evictQueries();
+    public void evictQueries() throws HibernateException {
+        getSessionFactory().getCache().evictQueryRegions();
     }
 
-    public void evictQueries(String cacheRegion) throws HibernateException
-    {
-        getSessionFactory().evictQueries(cacheRegion);
+    public void evictQueries(String cacheRegion) throws HibernateException {
+        getSessionFactory().getCache().evictQueryRegion(cacheRegion);
     }
 
-    public StatelessSession openStatelessSession()
-    {
+    public StatelessSession openStatelessSession() {
         return getSessionFactory().openStatelessSession();
     }
 
-    public StatelessSession openStatelessSession(Connection connection)
-    {
+    public StatelessSession openStatelessSession(Connection connection) {
         return getSessionFactory().openStatelessSession(connection);
     }
 
-    public Set getDefinedFilterNames()
-    {
+    public Set getDefinedFilterNames() {
         return getSessionFactory().getDefinedFilterNames();
     }
 
-    public Reference getReference() throws NamingException
-    {
+    public Reference getReference() throws NamingException {
         return getSessionFactory().getReference();
     }
 
-    public SessionFactory getSessionFactory()
-    {
+    public SessionFactory getSessionFactory() {
         SessionFactory sessionFactory = sessionFactories.get(determineCurrentSessionFactoryKey());
 
-        if (sessionFactory == null)
-        {
-
+        if (sessionFactory == null) {
+            throw new HibernateException("Session Factory is null");
         }
 
         return sessionFactory;

--- a/db-support/src/main/java/com/carbonfive/db/hibernate/sessionfactory/RoutingSessionFactory.java
+++ b/db-support/src/main/java/com/carbonfive/db/hibernate/sessionfactory/RoutingSessionFactory.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class RoutingSessionFactory implements SessionFactory {
-    private Map<Object, SessionFactory> sessionFactories = new HashMap<>();
-    private EntityManager entityManager = getSessionFactory().createEntityManager();
+    private final Map<Object, SessionFactory> sessionFactories = new HashMap<>();
+    private final EntityManager entityManager = getSessionFactory().createEntityManager();
 
     public FilterDefinition getFilterDefinition(String filterName) throws HibernateException {
         return getSessionFactory().getFilterDefinition(filterName);

--- a/db-support/src/main/java/com/carbonfive/db/hibernate/usertypes/EnumUserType.java
+++ b/db-support/src/main/java/com/carbonfive/db/hibernate/usertypes/EnumUserType.java
@@ -1,6 +1,7 @@
 package com.carbonfive.db.hibernate.usertypes;
 
 import org.hibernate.*;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.usertype.*;
 
 import java.io.*;
@@ -8,7 +9,7 @@ import java.sql.*;
 import java.util.*;
 
 /**
- * A hibernate user type for mapping Java 1.5 enum types to and from database columns.  Can be used as identifiers or discriminators.
+ * A hibernated user type for mapping Java 1.5 enum types to and from database columns.  Can be used as identifiers or discriminators.
  * <p/>
  * The name of the enum is stored in the database.  For more control over what code is persisted, see EnhancedEnumUserType.
  * <p/>
@@ -66,6 +67,16 @@ public class EnumUserType implements EnhancedUserType, ParameterizedType
         return x.hashCode();
     }
 
+    @Override
+    public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session) throws SQLException {
+
+    }
+
     public boolean isMutable()
     {
         return false;
@@ -94,6 +105,11 @@ public class EnumUserType implements EnhancedUserType, ParameterizedType
         return original;
     }
 
+    @Override
+    public int getSqlType() {
+        return 0;
+    }
+
     public Class returnedClass()
     {
         return enumClass;
@@ -104,19 +120,18 @@ public class EnumUserType implements EnhancedUserType, ParameterizedType
         return new int[] { Types.VARCHAR };
     }
 
-    public String objectToSQLString(Object value)
-    {
+    @Override
+    public String toSqlLiteral(Object value) {
         return '\'' + ((Enum) value).name() + '\'';
     }
 
-    public String toXMLString(Object value)
-    {
+    @Override
+    public String toString(Object value) throws HibernateException {
         return ((Enum) value).name();
     }
 
-    public Object fromXMLString(String xmlValue)
-    {
-        return Enum.valueOf(enumClass, xmlValue);
+    @Override
+    public Object fromStringValue(CharSequence sequence) throws HibernateException {
+        return Enum.valueOf(enumClass, sequence.toString());
     }
-
 }

--- a/db-support/src/main/java/com/carbonfive/db/jdbc/DatabaseUtils.java
+++ b/db-support/src/main/java/com/carbonfive/db/jdbc/DatabaseUtils.java
@@ -1,8 +1,16 @@
 package com.carbonfive.db.jdbc;
 
-import static com.carbonfive.db.jdbc.DatabaseType.*;
-import static org.apache.commons.lang.StringUtils.*;
-import org.apache.commons.lang.*;
+import org.apache.commons.lang3.Validate;
+
+import static com.carbonfive.db.jdbc.DatabaseType.DB2;
+import static com.carbonfive.db.jdbc.DatabaseType.H2;
+import static com.carbonfive.db.jdbc.DatabaseType.HSQL;
+import static com.carbonfive.db.jdbc.DatabaseType.MYSQL;
+import static com.carbonfive.db.jdbc.DatabaseType.ORACLE;
+import static com.carbonfive.db.jdbc.DatabaseType.POSTGRESQL;
+import static com.carbonfive.db.jdbc.DatabaseType.SQL_SERVER;
+import static com.carbonfive.db.jdbc.DatabaseType.UNKNOWN;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class DatabaseUtils
 {

--- a/db-support/src/main/java/com/carbonfive/db/jdbc/DatabaseUtils.java
+++ b/db-support/src/main/java/com/carbonfive/db/jdbc/DatabaseUtils.java
@@ -35,7 +35,7 @@ public class DatabaseUtils
         Validate.isTrue(isNotBlank(url));
 
         if (url.contains(POSTGRESQL_FRAGMENT)) { return "org.postgresql.Driver"; }
-        if (url.contains(MYSQL_FRAGMENT)) { return "com.mysql.jdbc.Driver"; }
+        if (url.contains(MYSQL_FRAGMENT)) { return "com.mysql.cj.jdbc.Driver"; }
         if (url.contains(HSQL_FRAGMENT)) { return "org.hsqldb.jdbcDriver"; }
         if (url.contains(H2_FRAGMENT)) { return "org.h2.Driver"; }
         if (url.contains(SQL_SERVER_JTDS_FRAGMENT)) { return "net.sourceforge.jtds.jdbc.Driver"; }

--- a/db-support/src/main/java/com/carbonfive/db/jdbc/ScriptRunner.java
+++ b/db-support/src/main/java/com/carbonfive/db/jdbc/ScriptRunner.java
@@ -8,8 +8,8 @@ import java.io.LineNumberReader;
 import java.io.Reader;
 import java.sql.*;
 
-import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
-import static org.apache.commons.lang.StringUtils.startsWithIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.startsWithIgnoreCase;
 
 public class ScriptRunner
 {

--- a/db-support/src/test/java/com/carbonfive/db/jdbc/datasource/RoutingDataSourceSpringTest.java
+++ b/db-support/src/test/java/com/carbonfive/db/jdbc/datasource/RoutingDataSourceSpringTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -48,7 +47,7 @@ public class RoutingDataSourceSpringTest
         for (String dataSourceName : dataSourceNames)
         {
             contextService.setCurrentClient(dataSourceName);
-            SimpleJdbcTemplate jdbcTemplate = new SimpleJdbcTemplate(dataSource);
+            JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
             String name = jdbcTemplate.queryForObject("select name from db_name", String.class, Collections.EMPTY_MAP);
             assertThat(name, is(dataSourceName));
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <parent>
-        <groupId>com.carbonfive</groupId>
-        <artifactId>c5-parent</artifactId>
-        <version>9</version>
-    </parent>
-
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.carbonfive.db-support</groupId>
     <artifactId>db-support-parent</artifactId>
@@ -42,11 +36,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
         <jdbc.host>localhost</jdbc.host>
-
-        <java.source>1.5</java.source>
-        <java.target>1.5</java.target>
+        <java.source>11</java.source>
+        <java.target>11</java.target>
+        <spring.version>5.3.27</spring.version>
     </properties>
 
     <scm>
@@ -72,15 +65,15 @@
         <dependencies>
             <dependency>
                 <groupId>com.mockrunner</groupId>
-                <artifactId>mockrunner</artifactId>
-                <version>0.4</version>
+                <artifactId>mockrunner-jms</artifactId>
+                <version>2.0.6</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.dbunit</groupId>
                 <artifactId>dbunit</artifactId>
-                <version>2.4.7</version>
+                <version>2.7.3</version>
                 <scope>test</scope>
             </dependency>
 
@@ -93,13 +86,13 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>1.4</version>
+                <version>2.13.0</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
             </dependency>
 
             <dependency>
@@ -109,15 +102,15 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.4</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>3.3.2.GA</version>
+                <version>6.2.4.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xml-apis</groupId>
@@ -139,9 +132,9 @@
             </dependency>
 
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.10</version>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>8.0.33</version>
             </dependency>
 
             <dependency>
@@ -174,16 +167,18 @@
         <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>${java.source}</source>
                     <target>${java.target}</target>
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <includes>
                         <include>**/Abstract*Test.java</include>
@@ -198,8 +193,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -211,19 +207,22 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.6.1</version>
+                <version>3.5.0</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.0</version>
+                <version>3.0.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>
             <plugin>
-                <version>2.1</version>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </organization>
 
     <prerequisites>
-        <maven>2.0.6</maven>
+        <maven>3.8.1</maven>
     </prerequisites>
 
     <modules>
@@ -45,21 +45,6 @@
     <scm>
         <connection>scm:svn:https://c5-db-migration.googlecode.com/svn/trunk/</connection>
     </scm>
-
-    <repositories>
-        <repository>
-            <id>c5-public-repository</id>
-            <name>Carbon Five Public Repository</name>
-            <url>http://mvn.carbonfive.com/public</url>
-            <snapshots>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>jboss-repository</id>
-            <url>http://repository.jboss.org/maven2</url>
-        </repository>
-    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -155,8 +140,8 @@
                 <version>1.6.2</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>junit</groupId>
-                        <artifactId>junit</artifactId>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
We want to use cb5 with newer spring versions so we need to upgrade the Spring version that it used to compiled and also uses newer versions and formats for the libraries that have some vulnerabilities.